### PR TITLE
Update @ts-morph/bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "typescript": "^3.7.3"
   },
   "dependencies": {
-    "@ts-morph/bootstrap": "^0.3.0"
+    "@ts-morph/bootstrap": "^0.4.0"
   }
 }


### PR DESCRIPTION
Version 0.3.0 uses typescript 3.7, wich makes transforming fail with typescript 3.8 during tests, even though using the transformer with ttypescript works.